### PR TITLE
Add GitHub Actions CI/CD deploy via GHCR + Docker Compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+.git
+.github
+.idea
+.qodo
+npm-debug.log*
+.env*.local
+.env.production
+*.md
+Dockerfile*
+docker-compose*.yml

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,9 @@
+# Copy this to `.env.production` on the server (next to docker-compose.prod.yml).
+# These are SERVER-SIDE only and are read by the contact-form API route.
+# They are NEVER baked into the image and NEVER exposed to the browser.
+NEXT_CONTACT_MAIL_HOST=server.gambit24.de
+NEXT_CONTACT_MAIL_SERVICE=gambit24mailer
+NEXT_CONTACT_MAIL_PORT=465
+NEXT_CONTACT_MAIL_USER=kontakt@rene-van-dinter.de
+NEXT_CONTACT_MAIL_PASS=CHANGE_ME
+NEXT_CONTACT_MAIL_ADDRESS=kontakt@rene-van-dinter.de

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,68 @@
+name: Build & Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/wizzard26/rvdportfolio
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.prod
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          echo "${{ secrets.DEPLOY_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy on server
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          ssh -i ~/.ssh/id_deploy "$DEPLOY_USER@$DEPLOY_HOST" \
+            "cd '$DEPLOY_PATH' \
+             && docker compose -f docker-compose.prod.yml pull \
+             && docker compose -f docker-compose.prod.yml up -d \
+             && docker image prune -f"

--- a/.gitignore
+++ b/.gitignore
@@ -27,12 +27,12 @@ yarn-error.log*
 # local env files
 .env*.local
 
+# server-side production secrets (never committed; lives only on the server)
+.env.production
+
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-
-# secure config
-next.config.js

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,26 @@
+# Production image for rvdportfolio — built in GitHub Actions, pushed to GHCR.
+# The server only pulls this image; it never builds.
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --legacy-peer-deps
+
+FROM node:20-alpine AS build
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS release
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/public ./public
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/next.config.js ./next.config.js
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,15 @@
+# Runs on the server in /home/users/rene/www/next.rene-van-dinter.de.
+# Deployed by user `deployer` (member of group `rene`); pulls the prebuilt image
+# from GHCR, never builds. Lives next to a `.env.production` (mode 640, rene:rene)
+# holding the mail secrets.
+services:
+  prod:
+    image: ghcr.io/wizzard26/rvdportfolio:latest
+    container_name: rd-portfolio-prod
+    restart: on-failure
+    ports:
+      - "3001:3000"
+    env_file:
+      - .env.production
+    environment:
+      - NODE_ENV=production

--- a/next.config.js
+++ b/next.config.js
@@ -4,11 +4,6 @@ const nextConfig = {
     compiler: {
         styledComponents: true,
     },
-    env: {
-        NEXT_PUBLIC_MAIL_USER: 'rene',
-        NEXT_PUBLIC_MAIL_PASS: 'LP8jnJ#V+L',
-        NEXT_PUBLIC_MAIL_ADDRESS: 'kontakt@rene-van-dinter.de'
-    }
 }
 
 module.exports = nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rvdportfolio",
       "version": "0.1.0",
       "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1",
         "eslint": "8.42.0",
         "eslint-config-next": "13.4.5",
         "framer-motion": "^10.16.14",
@@ -2080,6 +2081,17 @@
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@next/env": {
       "version": "13.4.9",
@@ -4567,6 +4579,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="
     },
     "node_modules/jsesc": {
       "version": "2.5.2",

--- a/src/app/api/sendmail/route.js
+++ b/src/app/api/sendmail/route.js
@@ -5,14 +5,16 @@ export async function POST(request){
     try {
         const {gender, title, firstName, lastName, company, phone, mail, webUrl, message, sendCopy} = await request.json();
 
+        const mailPort = Number(process.env.NEXT_CONTACT_MAIL_PORT) || 465;
+
         const transporter = nodemailer.createTransport({
-            service: 'gambit24mailer',
-            host: 'server.gambit24.de',
-            port: 465,
-            secure: true,
+            service: process.env.NEXT_CONTACT_MAIL_SERVICE || 'gambit24mailer',
+            host: process.env.NEXT_CONTACT_MAIL_HOST || 'server.gambit24.de',
+            port: mailPort,
+            secure: mailPort === 465,
             auth: {
-                user: process.env.NEXT_PUBLIC_MAIL_ADDRESS,
-                pass: process.env.NEXT_PUBLIC_MAIL_PASS
+                user: process.env.NEXT_CONTACT_MAIL_ADDRESS,
+                pass: process.env.NEXT_CONTACT_MAIL_PASS
             }
         })
 


### PR DESCRIPTION
Replaces the manual FTP-upload + manual docker restart workflow with an automated pipeline:

- .github/workflows/deploy.yml: on push to main, build Dockerfile.prod and push to ghcr.io/wizzard26/rvdportfolio, then SSH to the server as the `deployer` user and `docker compose pull && up -d` (registry-based, the server never builds).
- Dockerfile.prod: clean multi-stage production image.
- docker-compose.prod.yml: server-side compose that pulls the GHCR image, binds 3001:3000 (unchanged for the KeyHelp reverse proxy), reads secrets from .env.production.
- .dockerignore / .env.production.example: build hygiene + secret template.

Secret handling fixed: removed the mail password from next.config.js (which exposed it via NEXT_PUBLIC_* in the client bundle) and un-ignored the now secret-free next.config.js. The contact API route now reads server-side NEXT_CONTACT_MAIL_* env vars instead.