### PR TITLE
Fix deploy job environment name (production -> Deployment-RVD)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment: production
+    environment: Deployment-RVD
     steps:
       - name: Set up SSH
         run: |


### PR DESCRIPTION
The deploy secrets (DEPLOY_SSH_KEY, DEPLOY_HOST, DEPLOY_USER, DEPLOY_PATH, DEPLOY_KNOWN_HOSTS) live in the `Deployment-RVD` environment, but the deploy job referenced `environment: production` (empty), so all secrets resolved to empty strings and the ssh command failed with exit 255.