### PR TITLE
Use next/image for showcase galleries

### DIFF
--- a/src/components/showcases/ShowBox.js
+++ b/src/components/showcases/ShowBox.js
@@ -1,5 +1,8 @@
 import {roboto} from "@/app/fonts";
 import TechTags from "./TechTags";
+import Image from "next/image";
+
+const SIZES = "(max-width: 575px) 100vw, (max-width: 767px) 50vw, (max-width: 991px) 33vw, (max-width: 1199px) 25vw, 16vw";
 
 export default function ShowBox({headline,data, boxClass = 'web', category = ''}) {
     const caseEntries = data.filter((entry) => entry.category === category);
@@ -13,9 +16,8 @@ export default function ShowBox({headline,data, boxClass = 'web', category = ''}
                     <div key={entry.id} className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
                         <div className={`card card-cases`}>
                             <div className={`card-image card-image-${boxClass}`}>
-                                <img src={`/img/casestudy/${entry.imgPath}/${entry.image}`}
-                                     alt={entry.title} width={900}
-                                     height={900}/>
+                                <Image src={`/img/casestudy/${entry.imgPath}/${entry.image}`}
+                                       alt={entry.title} width={900} height={900} sizes={SIZES}/>
                             </div>
                             <div className={`card-content`}>
                                 <h3 className={roboto.className}>{entry.title}</h3>

--- a/src/components/showcases/ShowJavascripts.js
+++ b/src/components/showcases/ShowJavascripts.js
@@ -5,6 +5,9 @@ import Slider from "@/components/scripts/Slider";
 import Lottogenerator from "@/components/scripts/Lottogenerator";
 import Cartsystem from "@/components/scripts/Cartsystem";
 import Modalbox from "@/components/scripts/Modalbox";
+import Image from "next/image";
+
+const SIZES = "(max-width: 575px) 100vw, (max-width: 767px) 50vw, (max-width: 991px) 33vw, (max-width: 1199px) 25vw, 16vw";
 
 export default function ShowJavascripts() {
     return (
@@ -116,9 +119,9 @@ export default function ShowJavascripts() {
                         <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
                             <div className={`card card-cases`}>
                                 <div className={`card-image card-image-info`}>
-                                    <img src={`/img/blog/code.jpg`}
+                                    <Image src={`/img/blog/code.jpg`}
                                          alt={`Futterbedarfsrechner`} width={900}
-                                         height={900}/>
+                                         height={900} sizes={SIZES}/>
                                 </div>
                                 <div className={`card-content`}>
                                     <h3 className={roboto.className}>Futterrechner</h3>
@@ -131,9 +134,9 @@ export default function ShowJavascripts() {
                         <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
                             <div className={`card card-cases`}>
                                 <div className={`card-image card-image-info`}>
-                                    <img src={`/img/blog/code.jpg`}
+                                    <Image src={`/img/blog/code.jpg`}
                                          alt={`Optimix Futterrechner`} width={900}
-                                         height={900}/>
+                                         height={900} sizes={SIZES}/>
                                 </div>
                                 <div className={`card-content`}>
                                     <h3 className={roboto.className}>Optimix Rechner</h3>
@@ -146,9 +149,9 @@ export default function ShowJavascripts() {
                         <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
                             <div className={`card card-cases`}>
                                 <div className={`card-image card-image-info`}>
-                                    <img src={`/img/blog/code.jpg`}
+                                    <Image src={`/img/blog/code.jpg`}
                                          alt={`Dart Scorer`} width={900}
-                                         height={900}/>
+                                         height={900} sizes={SIZES}/>
                                 </div>
                                 <div className={`card-content`}>
                                     <h3 className={roboto.className}>Darts Scorer</h3>
@@ -160,9 +163,9 @@ export default function ShowJavascripts() {
                         <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
                             <div className={`card card-cases`}>
                                 <div className={`card-image card-image-info`}>
-                                    <img src={`/img/blog/code.jpg`}
+                                    <Image src={`/img/blog/code.jpg`}
                                          alt={`Mega Menue`} width={900}
-                                         height={900}/>
+                                         height={900} sizes={SIZES}/>
                                 </div>
                                 <div className={`card-content`}>
                                     <h3 className={roboto.className}>Mega Menü</h3>
@@ -175,9 +178,9 @@ export default function ShowJavascripts() {
                         <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
                             <div className={`card card-cases`}>
                                 <div className={`card-image card-image-info`}>
-                                    <img src={`/img/blog/code.jpg`}
+                                    <Image src={`/img/blog/code.jpg`}
                                          alt={`Collapese Boxen`} width={900}
-                                         height={900}/>
+                                         height={900} sizes={SIZES}/>
                                 </div>
                                 <div className={`card-content`}>
                                     <h3 className={roboto.className}>Collapse Boxen</h3>
@@ -189,9 +192,9 @@ export default function ShowJavascripts() {
                         <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
                             <div className={`card card-cases`}>
                                 <div className={`card-image card-image-info`}>
-                                    <img src={`/img/blog/code.jpg`}
+                                    <Image src={`/img/blog/code.jpg`}
                                          alt={`Filter System`} width={900}
-                                         height={900}/>
+                                         height={900} sizes={SIZES}/>
                                 </div>
                                 <div className={`card-content`}>
                                     <h3 className={roboto.className}>Inhalts Filter</h3>

--- a/src/components/showcases/ShowLogos.js
+++ b/src/components/showcases/ShowLogos.js
@@ -1,132 +1,37 @@
 import {roboto} from "@/app/fonts";
+import Image from "next/image";
+
+const SIZES = "(max-width: 575px) 100vw, (max-width: 767px) 50vw, (max-width: 991px) 33vw, (max-width: 1199px) 25vw, 16vw";
+
+const logos = [
+    {src: "/img/casestudy/logo/LandhotelKirchberger1.jpg", alt: "Landhotel Kirchberger"},
+    {src: "/img/casestudy/logo/medexo.jpg", alt: "Medexo"},
+    {src: "/img/casestudy/logo/sannova.png", alt: "Sannova"},
+    {src: "/img/casestudy/logo/tomateBasilic.jpg", alt: "Tomate Basilic"},
+    {src: "/img/casestudy/logo/prinzImmo3_2.jpg", alt: "Prinz Immobilien"},
+    {src: "/img/casestudy/logo/roomlab.png", alt: "Roomlab"},
+    {src: "/img/casestudy/logo/Logo-Block.png", alt: "Rene van Dinter"},
+    {src: "/img/casestudy/logo/tcc-logo.png", alt: "Chauffeur College"},
+    {src: "/img/casestudy/logo/vita-logo.png", alt: "Vitales"},
+    {src: "/img/casestudy/logo/gbsnord-logo.png", alt: "GBS Nord"},
+    {src: "/img/casestudy/logo/cklix.jpg", alt: "Clix AG"},
+    {src: "/img/casestudy/logo/Survival_Logo.jpg", alt: "Survival New Order"},
+];
 
 export default function ShowLogos() {
     return (
         <>
             <h2 className={`${roboto.className} is--centered`}>Logo Designs</h2>
             <div className={`row`}>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/logo/LandhotelKirchberger1.jpg"
-                                 alt="Landhotel Kirchberger"
-                                 width={900}
-                                 height={900}/>
+                {logos.map((logo) => (
+                    <div key={logo.src} className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
+                        <div className={`card card-cases`}>
+                            <div className={`card-image card-image-logo`}>
+                                <Image src={logo.src} alt={logo.alt} width={900} height={900} sizes={SIZES}/>
+                            </div>
                         </div>
                     </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/logo/medexo.jpg" alt="Medexo"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/logo/sannova.png" alt="Sannova"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/logo/tomateBasilic.jpg" alt="Tomate Basilic"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/logo/prinzImmo3_2.jpg" alt="Prinz Immobilien"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/logo/roomlab.png" alt="Roomlab"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/logo/Logo-Block.png" alt="Rene van Dinter"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/logo/tcc-logo.png" alt="Chauffeur College"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/logo/vita-logo.png" alt="Vitales"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/logo/gbsnord-logo.png" alt="GBS Nord"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/logo/cklix.jpg" alt="Clix AG"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/logo/Survival_Logo.jpg" alt="Survival New Order"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
+                ))}
             </div>
         </>
     )

--- a/src/components/showcases/ShowPrints.js
+++ b/src/components/showcases/ShowPrints.js
@@ -1,75 +1,31 @@
 import {roboto} from "@/app/fonts";
+import Image from "next/image";
+
+const SIZES = "(max-width: 575px) 100vw, (max-width: 767px) 50vw, (max-width: 991px) 33vw, (max-width: 1199px) 25vw, 16vw";
+
+const prints = [
+    {src: "/img/casestudy/print/cascade.png", alt: "Cascade Darts"},
+    {src: "/img/casestudy/print/dr_reiser.png", alt: "Reiser Ärzte"},
+    {src: "/img/casestudy/print/EWS_Windenergy.png", alt: "EWS Windenergy"},
+    {src: "/img/casestudy/print/flyerKleineKneipe.png", alt: "Andres kleine Kneipe"},
+    {src: "/img/casestudy/print/gbs_nord.webp", alt: "GBS Nord"},
+    {src: "/img/casestudy/print/woznyCD.jpg", alt: "Wozny Photography"},
+];
 
 export default function ShowPrints() {
     return (
         <>
             <h2 className={`${roboto.className} is--centered`}>Print Designs</h2>
             <div className={`row`}>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/print/cascade.png"
-                                 alt="Cascade Darts"
-                                 width={900}
-                                 height={900}/>
+                {prints.map((print) => (
+                    <div key={print.src} className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
+                        <div className={`card card-cases`}>
+                            <div className={`card-image card-image-logo`}>
+                                <Image src={print.src} alt={print.alt} width={900} height={900} sizes={SIZES}/>
+                            </div>
                         </div>
                     </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/print/dr_reiser.png"
-                                 alt="Reiser Ärzte"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/print/EWS_Windenergy.png"
-                                 alt="EWS Windenergy"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/print/flyerKleineKneipe.png"
-                                 alt="Andres kleine Kneipe"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/print/gbs_nord.webp"
-                                 alt="Gbs Nord"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
-                <div className={`col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2`}>
-                    <div className={`card card-cases`}>
-                        <div className={`card-image card-image-logo`}>
-                            <img src="/img/casestudy/print/woznyCD.jpg"
-                                 alt="Wozny Photography"
-                                 width={900}
-                                 height={900}/>
-                        </div>
-                    </div>
-                </div>
-
+                ))}
             </div>
         </>
     )


### PR DESCRIPTION
Convert layout/logo/print/JS-tab images to next/image (webp+srcset+lazy). Slider kept on <img>. Browser-verified: optimizer active, none broken, ratios preserved.